### PR TITLE
Fix travis CI and coverage labels

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,9 @@ install:
   - luarocks install luacov
   - luarocks install luacov-coveralls
 
+before_script:
+  - cd dice_test
+
 script:
   - lua dice_test.lua -v --coverage
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ before_script:
   - cd tests
 
 script:
-  - lua dice_test.lua -v --coverage
+  - lua dice_test.lua -v
 
 after_success:
   - luacov-coveralls --exclude $TRAVIS_BUILD_DIR/lua_install

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,6 @@ sudo: false
 env:
   - LUA="lua=5.1"
   - LUA="lua=5.2"
-  - LUA="lua=5.3"
-  - LUA="lua=5.4"
   - LUA="luajit=2.0"
   - LUA="luajit=2.1"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ install:
   - luarocks install luacov-coveralls
 
 before_script:
-  - cd dice_test
+  - cd tests
 
 script:
   - lua dice_test.lua -v --coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,10 +21,11 @@ before_script:
   - cd tests
 
 script:
+  - lua -v -lluacov dice_test.lua
   - lua dice_test.lua -v
 
 after_success:
-  - luacov-coveralls --exclude $TRAVIS_BUILD_DIR/lua_install
+  - luacov-coveralls -v --include dice.lua
 
 branches:
   only:

--- a/README.md
+++ b/README.md
@@ -9,6 +9,14 @@ RL-Dice
 
 A robust module to roll and manipulate roguelike dice.  This has also been included in [rotLove](https://github.com/paulofmandown/rotLove) roguelike toolkit which I highly recommend if you plan on making a roguelike.
 
+This library is compatible with:
+
+* Lua 5.1
+* Lua 5.2
+* Luajit 2.0
+* Luajit 2.1
+* Love2D
+
 Consult the [online documentation](https://timothymtorres.github.io/RL-Dice) for the API and usage examples.  
 
 The dice module provides the following:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-[![Build Status](https://app.travis-ci.com/timothymtorres/RL-Dice.svg?branch=master)](https://app.travis-ci.com/timothymtorres/RL-Dice)
-[![Coverage Status](https://coveralls.io/repos/github/timothymtorres/RL-Dice/badge.svg?branch=master)](https://coveralls.io/github/timothymtorres/RL-Dice?branch=master)
+[![Build Status](https://app.travis-ci.com/timothymtorres/RL-Dice.svg)](https://app.travis-ci.com/timothymtorres/RL-Dice)
+[![Coverage Status](https://coveralls.io/repos/github/timothymtorres/RL-Dice/badge.svg)](https://coveralls.io/github/timothymtorres/RL-Dice)
 [![github](https://img.shields.io/github/license/timothymtorres/RL-Dice.svg)](https://choosealicense.com/licenses/mit/)
 [![tags](https://img.shields.io/github/tag/timothymtorres/RL-dice.svg?label=version)](https://github.com/timothymtorres/RL-Dice/tags)
 [![commit](https://img.shields.io/github/last-commit/timothymtorres/rl-dice.svg)](https://github.com/timothymtorres/RL-Dice/commits/master)


### PR DESCRIPTION
This fixes the directory for where the travis CI and coverage status are located.  This also removes the tests for Lua 5.3 and Lua 5.4 since this library breaks when using them.  